### PR TITLE
Let Nosetests be configured with other options

### DIFF
--- a/testtube/helpers.py
+++ b/testtube/helpers.py
@@ -162,7 +162,7 @@ class Nosetests(Helper):
         all_files=False will be ignored.
 
         """
-        super(Nosetests, self).__init__()
+        super(Nosetests, self).__init__(**kwargs)
 
         # Nosetests only works on all files, so override any config for this
         # value.

--- a/testtube/tests/test_helpers.py
+++ b/testtube/tests/test_helpers.py
@@ -110,11 +110,14 @@ class FrotedHelperNotConfiguredToCheckAllFiles(HelperTests):
 
 
 class NosetestsHelper(HelperTests):
-    helper_conf = {'all_files': False}
+    helper_conf = {'all_files': False, 'name': 'tests'}
     helper_class = Nosetests
 
     def test_doesnt_allow_itself_to_be_configured_to_check_single_files(self):
         self.assertTrue(self.helper.all_files)
+
+    def test_does_allow_itself_to_be_configured_with_other_options(self):
+        self.assertEqual(self.helper.name, 'tests')
 
 
 class PythonSetupPyHelper(HelperTests):


### PR DESCRIPTION
Fixes bug where kwargs weren't being passed to the parent Helper class.